### PR TITLE
Make uri printing and parsing symmetric.

### DIFF
--- a/cl-gopher.lisp
+++ b/cl-gopher.lisp
@@ -493,9 +493,10 @@
   #.(format nil "URI-FOR-GOPHER-LINE takes a GOPHER-LINE and returns~@
                  a string containing a gopher uri representing the~@
                  resource the line points to.")
-  (if (or (null (selector gl))
-          (equal (selector gl) "")
-          (equal (selector gl) "/"))
-      (format nil "gopher://~a:~a/" (hostname gl) (port gl))
-      (format nil "gopher://~a:~a/~c~a"
-              (hostname gl) (port gl) (type-character gl) (selector gl))))
+  (format nil "gopher://~a~:[:~a~;~*~]/~@[~*~c~a~]"
+          (hostname gl)
+          (eql (port gl) 70) (port gl)
+          (not (or (null (selector gl))
+                   (equal (selector gl) "")
+                   (equal (selector gl) "/")))
+          (type-character gl) (selector gl)))


### PR DESCRIPTION
This changes `uri-for-gopher-line` in a backwards-compatible manner, to be more consistent with `parse-gopher-uri`'s behavior. To be more precise, `uri-for-gopher-line` prints no port it it's 70, much like `parse-gopher-uri` using port 70 if it's not provided.

In other words,
``` lisp
(string= (uri-for-gopher-line (parse-gopher-uri uri)) uri)
```
should now be true for all the valid Gopher URIs.

As an unnecessary stylistic change, conditional formatters are used instead of explicit `if`-s to reduce code duplication.