### PR TITLE
Search strings

### DIFF
--- a/cl-gopher-package.lisp
+++ b/cl-gopher-package.lisp
@@ -1,5 +1,5 @@
 (defpackage :cl-gopher
-  (:use :cl :split-sequence)
+  (:use :cl)
   (:documentation
    #.(format nil "cl-gopher is a Common Lisp library for interacting with~@
                   the Gopher protocol. It is suitable for building both~@

--- a/cl-gopher.asd
+++ b/cl-gopher.asd
@@ -3,7 +3,7 @@
   :description "Gopher protocol library"
   :license "BSD 2-Clause"
   :author "Kyle Nusbaum"
-  :depends-on (#:split-sequence #:usocket #:flexi-streams #:drakma #:bordeaux-threads #:quri)
+  :depends-on (#:usocket #:flexi-streams #:drakma #:bordeaux-threads #:quri)
   :components ((:file "cl-gopher-package")
                (:file "cl-gopher"
                       :depends-on ("cl-gopher-package"))

--- a/cl-gopher.lisp
+++ b/cl-gopher.lisp
@@ -72,7 +72,8 @@
   ((display-string :initform nil :initarg :display-string :accessor display-string)
    (selector :initform nil :initarg :selector :accessor selector)
    (hostname :initform nil :initarg :hostname :accessor hostname)
-   (port :initform nil :initarg :port :accessor port))
+   (port :initform nil :initarg :port :accessor port)
+   (terms :initform "" :initarg :terms :accessor terms))
   (:documentation
    #.(format nil "A GOPHER-LINE represents a gopher menu item,~@
                   (analogous to an html link).~@
@@ -89,8 +90,7 @@
 (defclass binhex-file (gopher-line) ())
 (defclass dos-file (gopher-line) ())
 (defclass uuencoded-file (gopher-line) ())
-(defclass search-line (gopher-line)
-  ((terms :initform "" :initarg :terms :accessor terms)))
+(defclass search-line (gopher-line))
 (defclass telnet (gopher-line) ())
 (defclass binary-file (gopher-line) ())
 (defclass mirror (gopher-line) ())
@@ -161,13 +161,6 @@
 
 (defmethod copy-gopher-line ((gl gopher-line))
   (make-instance (class-of gl)
-                 :display-string (display-string gl)
-                 :selector (selector gl)
-                 :hostname (hostname gl)
-                 :port (port gl)))
-
-(defmethod copy-gopher-line ((gl search-line))
-  (make-instance 'search-line
                  :display-string (display-string gl)
                  :selector (selector gl)
                  :hostname (hostname gl)
@@ -491,8 +484,7 @@
              :selector selector
              :hostname host
              :port port
-             (when (and terms (eq item-type :search-line))
-               `(:terms ,terms))))))
+             :terms terms))))
 
 (defun uri-for-gopher-line (gl)
   #.(format nil "URI-FOR-GOPHER-LINE takes a GOPHER-LINE and returns~@

--- a/cl-gopher.lisp
+++ b/cl-gopher.lisp
@@ -484,10 +484,8 @@
            (tab-split-selector (uiop:split-string selector :separator '(#\Tab)))
            (selector (first tab-split-selector))
            (terms (second tab-split-selector))
-           (gopher+string (third tab-split-selector))
            (host (quri:uri-host uri))
            (port (or (quri:uri-port uri) 70)))
-      (declare (ignore gopher+string))
       (apply #'make-instance (class-for-type item-type)
              :display-string display-string
              :selector selector

--- a/cl-gopher.lisp
+++ b/cl-gopher.lisp
@@ -478,16 +478,23 @@
             (if (and (>= (length uri) 9) (equal "gopher://" (subseq uri 0 9)))
                 (quri:uri uri)
                 (quri:uri (format nil "gopher://~a" uri))))
-           (path (quri:uri-path uri))
+           (path (quri:url-decode (quri:uri-path uri)))
            (item-type (compute-item-type uri path))
            (selector (compute-selector uri path))
+           (tab-split-selector (uiop:split-string selector :separator '(#\Tab)))
+           (selector (first tab-split-selector))
+           (terms (second tab-split-selector))
+           (gopher+string (third tab-split-selector))
            (host (quri:uri-host uri))
            (port (or (quri:uri-port uri) 70)))
-      (make-instance (class-for-type item-type)
-                     :display-string display-string
-                     :selector selector
-                     :hostname host
-                     :port port))))
+      (declare (ignore gopher+string))
+      (apply #'make-instance (class-for-type item-type)
+             :display-string display-string
+             :selector selector
+             :hostname host
+             :port port
+             (when (and terms (eq item-type :search-line))
+               `(:terms ,terms))))))
 
 (defun uri-for-gopher-line (gl)
   #.(format nil "URI-FOR-GOPHER-LINE takes a GOPHER-LINE and returns~@

--- a/cl-gopher.lisp
+++ b/cl-gopher.lisp
@@ -490,10 +490,11 @@
   #.(format nil "URI-FOR-GOPHER-LINE takes a GOPHER-LINE and returns~@
                  a string containing a gopher uri representing the~@
                  resource the line points to.")
-  (format nil "gopher://~a~:[:~a~;~*~]/~@[~*~c~a~]"
+  (format nil "gopher://~a~:[:~a~;~*~]/~@[~*~c~a~]~@[~*%09~a~]"
           (hostname gl)
           (eql (port gl) 70) (port gl)
           (not (or (null (selector gl))
                    (equal (selector gl) "")
                    (equal (selector gl) "/")))
-          (type-character gl) (selector gl)))
+          (type-character gl) (selector gl)
+          (not (uiop:emptyp (terms gl))) (terms gl)))

--- a/cl-gopher.lisp
+++ b/cl-gopher.lisp
@@ -260,7 +260,7 @@
     (when (and line
                (not (equal line "."))
                (> (length line) 0))
-      (let ((line-elems (split-sequence #\tab (subseq line 1)))
+      (let ((line-elems (uiop:split-string (subseq line 1) :separator '(#\Tab)))
             (type (type-for-character (elt line 0))))
         (if (eq type :unknown)
             (make-unknown line-elems)


### PR DESCRIPTION
This adds search string parsing for Tab-separated paths, as per [RFC4266](https://www.rfc-editor.org/rfc/rfc4266.html#section-2.2). It allows constructing search lines with search terms derived from URIs, which wasn't possible before this patch.

There's also parsing of Gopher+ path part, but it's not used anywhere. It doesn't hurt having this spec-conformant element, though.