### PR TITLE
Use stricter format conditionals.

### DIFF
--- a/cl-gopher.lisp
+++ b/cl-gopher.lisp
@@ -490,11 +490,11 @@
   #.(format nil "URI-FOR-GOPHER-LINE takes a GOPHER-LINE and returns~@
                  a string containing a gopher uri representing the~@
                  resource the line points to.")
-  (format nil "gopher://~a~:[:~a~;~*~]/~@[~*~c~a~]~@[~*%09~a~]"
+  (format nil "gopher://~a~:[:~a~;~*~]/~:[~c~a~;~2*~]~:[%09~a~;~*~]"
           (hostname gl)
           (eql (port gl) 70) (port gl)
-          (not (or (null (selector gl))
-                   (equal (selector gl) "")
-                   (equal (selector gl) "/")))
+          (or (null (selector gl))
+              (equal (selector gl) "")
+              (equal (selector gl) "/"))
           (type-character gl) (selector gl)
-          (not (uiop:emptyp (terms gl))) (quri:url-encode (terms gl))))
+          (uiop:emptyp (terms gl)) (quri:url-encode (or (terms gl) ""))))


### PR DESCRIPTION
@knusbaum, I'm really sorry for pinging you that often, but I have discovered unpredictable bug in the code I contributed and want to fix it :)

This uses two-branched `~:[` conditionals instead of `~@[`, as latter are only suitable for one argument printing, thus breaking the URI printing when fed improper data.

I'll understand if you'll consider it more maintainable to rewrite these `format` strings as separate `if`-s and string concatenation, and I'm ready to do it.