### PR TITLE
Use UTF-8 as the default encoding.

### DIFF
--- a/cl-gopher.lisp
+++ b/cl-gopher.lisp
@@ -275,7 +275,7 @@
     `(let* ((,sock (usocket:socket-connect ,host ,port :element-type '(unsigned-byte 8)))
             (,stream (flexi-streams:make-flexi-stream
                       (usocket:socket-stream ,sock)
-                      :external-format (flexi-streams:make-external-format :iso-8859-1
+                      :external-format (flexi-streams:make-external-format :utf-8
                                                                            :eol-style :crlf)))
             (babel-encodings:*suppress-character-coding-errors* t))
        (unwind-protect


### PR DESCRIPTION
This is a simple fix to use UTF-8 as the default encoding when requesting Gopher resources. I'm pretty sure it would work better than ISO-8859-1 there :)

@knusbaum, any particular reason to use ISO-8859-1?