### PR TITLE
Clarify the server-side use instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,9 @@ CL-USER> (let ((lines (list
                                       :port 70
                                       :selector "/Documents"
                                       :display-string "View myserver.org's documents."))))
-           (mapcar (lambda (gl) (cl-gopher:write-gopher-line gl remote-sock)) lines))
+           (mapcar (lambda (gl) (cl-gopher:write-gopher-line gl :stream (usocket:socket-stream remote-sock))) lines)
+           (write-line "." (usocket:socket-stream remote-sock))
+           (force-output (usocket:socket-stream remote-sock)))
 ```
 Output sent to remote:
 ```


### PR DESCRIPTION
I've tried to make my Gopher server with the help of `cl-gopher` today, and it seemed to not work with the example from the README. Luckily, there's not much to change to make it work — we only have to output the dot and `force-output`!

@knusbaum, looks sane to you?